### PR TITLE
Update dirTagbox.js

### DIFF
--- a/src/directives/tagbox/dirTagbox.js
+++ b/src/directives/tagbox/dirTagbox.js
@@ -80,7 +80,7 @@ angular.module('angularUtils.directives.dirTagBox', [ 'angularUtils.filters.star
                     var candidateChanged = false;
                     var currentCaretIndex = getCaret(input[0]);
                     var text = input.val();
-                    var regexp = new RegExp(TOKEN + "[a-zA-Z0-9_]+","g");
+                    var regexp = new RegExp('\\B' + TOKEN + '\\w+', 'g');
                     var match;
                     while ((match = regexp.exec(text)) != null) {
                         var startOfHashtag = match.index;


### PR DESCRIPTION
This makes sure that a tag has to start with a space (or be at the beginning of the sentence). This fixes the problem when you're trying to enter an url with a hash (or an email address when the token is an at symbol).
