### PR TITLE
dirPagination: init pagination.current value from paginationService

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -200,6 +200,7 @@ angular.module('angularUtils.directives.dirPagination', [])
 
                 function generatePagination() {
                     scope.pages = generatePagesArray(1, paginationService.getCollectionLength(), paginationService.getItemsPerPage(), paginationRange);
+                    scope.pagination.current = parseInt(paginationService.getCurrentPage());
                     scope.pagination.last = scope.pages[scope.pages.length - 1];
                     if (scope.pagination.last < scope.pagination.current) {
                         scope.setCurrent(scope.pagination.last);


### PR DESCRIPTION
It seems like `pagination.current` is not been set up properly from the `paginationService.getCurrentPage`.

This simple change fixed my problem but I might be missing something.
