### PR TITLE
itemsPerPage filter sometimes gets a string

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -255,7 +255,7 @@
             var end;
             var start;
             if (collection instanceof Array) {
-                itemsPerPage = itemsPerPage || 9999999999;
+                itemsPerPage = parseInt(itemsPerPage) || 9999999999;
                 if (paginationService.isAsyncMode(paginationId)) {
                     start = 0;
                 } else {


### PR DESCRIPTION
Which breaks the calculation of the end variable as the + sign then concatenates the string instead of adding as a number.
