### PR TITLE
allowing "track by" in ng-repeat

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -57,8 +57,7 @@
                 if (!match[4]) {
                     throw 'pagination directive: the \'itemsPerPage\' filter must be set.';
                 }
-                var itemsPerPageFilterRemoved = match[2];
-                var collectionGetter = $parse(itemsPerPageFilterRemoved);
+                var collectionGetter = $parse(match[2]);
 
                 var paginationId = tAttrs.paginationId || '__default';
                 paginationService.registerInstance(paginationId);


### PR DESCRIPTION
I combined the regex's used to test for itemsPerPage, and fixed an issue I found when trying to use the following functionality:
https://docs.angularjs.org/error/ngRepeat/dupes
