### PR TITLE
export itemsPerPage and totalItems to a template of the paginator

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -208,6 +208,12 @@
                 };
 
                 scope.$watch(function() {
+                    return paginationService.getCollectionLength(paginationId);
+                }, function(length) {
+                    scope.pagination.totalItems = length;
+                });
+
+                scope.$watch(function() {
                     return (paginationService.getCollectionLength(paginationId) + 1) * paginationService.getItemsPerPage(paginationId);
                 }, function(length) {
                     if (0 < length) {


### PR DESCRIPTION
Hi, please review my pool request. It allows to create of pagination templates more flexible.
e.g.

```
<div  >
  <span> {{(pagination.current - 1) * pagination.itemsPerPage + 1 }}-{{pagination.current * pagination.itemsPerPage }} of {{pagination.totalItems}}</span>
  <a href="" title="Switch left" ng-if="directionLinks"
     ng-class="{ disabled : pagination.current == 1 }" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a>
  <a href="" class="g-switch-right" ng-class="{ disabled : pagination.current == pagination.last }"
     ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a>
</div>
```

It will be look as
![paginator](https://cloud.githubusercontent.com/assets/6583360/5436047/7ecec6c6-846a-11e4-8e1d-4ea2042e969c.png)

For now it's not possible.
