### PR TITLE
dirDisqus: added multi-language support

### DIFF
--- a/src/directives/disqus/dirDisqus.js
+++ b/src/directives/disqus/dirDisqus.js
@@ -34,9 +34,10 @@
                 disqus_url: '@disqusUrl',
                 disqus_category_id: '@disqusCategoryId',
                 disqus_disable_mobile: '@disqusDisableMobile',
+                disqus_config_language : '@disqusConfigLanguage',
                 readyToBind: "@"
             },
-            template: '<div id="disqus_thread"></div><a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>',
+            template: '<div id="disqus_thread"></div>',
             link: function(scope) {
 
                 // ensure that the disqus_identifier and disqus_url are both set, otherwise we will run in to identifier conflicts when using URLs with "#" in them
@@ -60,7 +61,9 @@
                         $window.disqus_url = scope.disqus_url;
                         $window.disqus_category_id = scope.disqus_category_id;
                         $window.disqus_disable_mobile = scope.disqus_disable_mobile;
-
+                        $window.disqus_config =  function () {
+                            this.language = scope.disqus_config_language;
+                        };
                         // get the remote Disqus script and insert it into the DOM, but only if it not already loaded (as that will cause warnings)
                         if (!$window.DISQUS) {
                             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
@@ -73,6 +76,7 @@
                                     this.page.identifier = scope.disqus_identifier;
                                     this.page.url = scope.disqus_url;
                                     this.page.title = scope.disqus_title;
+                                    this.language = scope.disqus_config_language;
                                 }
                             });
                         }

--- a/src/directives/disqus/dirDisqus.spec.js
+++ b/src/directives/disqus/dirDisqus.spec.js
@@ -13,6 +13,7 @@ xdescribe('dirDiqus directive', function() {
                            'disqus-url="{{ post.link }}"' +
                            'disqus-category-id="{{ post.catId }}"' +
                            'disqus-disable-mobile="false"' +
+						   'disqus-config-language="{{ post.lang }}"' +
                            'ready-to-bind="{{ loaded }}">' +
                 '</dir-disqus>';
 
@@ -23,7 +24,8 @@ xdescribe('dirDiqus directive', function() {
                 ID: 123,
                 title: 'test title',
                 link: 'http://www.test.com',
-                catId: 999
+                catId: 999,
+				lang: 'en'
             };
             scope.loaded = false;
 
@@ -50,6 +52,7 @@ xdescribe('dirDiqus directive', function() {
         expect(window.disqus_url).toBeFalsy();
         expect(window.disqus_category_id).toBeFalsy();
         expect(window.disqus_disable_mobile).toBeFalsy();
+        expect(window.disqus_config();window.language).toBeFalsy();
     });
 
     it('should activate when ready to bind is true', function() {
@@ -62,5 +65,6 @@ xdescribe('dirDiqus directive', function() {
         expect(window.disqus_url).toEqual('http://www.test.com');
         expect(window.disqus_category_id).toEqual('999');
         expect(window.disqus_disable_mobile).toEqual('false');
+        expect(window.disqus_config();window.language).toEqual('en');
     });
 });

--- a/src/directives/disqus/dirDisqus.spec.js
+++ b/src/directives/disqus/dirDisqus.spec.js
@@ -1,4 +1,4 @@
-xdescribe('dirDiqus directive', function() {
+xdescribe('dirDisqus directive', function() {
     var scope,
         elem,
         compiled,
@@ -8,14 +8,14 @@ xdescribe('dirDiqus directive', function() {
     beforeEach(function (){
         //set our view html.
         html = '<dir-disqus disqus-shortname="shortname" ' +
-                           'disqus-identifier="{{ post.ID }}"' +
-                           'disqus-title="{{ post.title }}"' +
-                           'disqus-url="{{ post.link }}"' +
-                           'disqus-category-id="{{ post.catId }}"' +
-                           'disqus-disable-mobile="false"' +
-						   'disqus-config-language="{{ post.lang }}"' +
-                           'ready-to-bind="{{ loaded }}">' +
-                '</dir-disqus>';
+        'disqus-identifier="{{ post.ID }}"' +
+        'disqus-title="{{ post.title }}"' +
+        'disqus-url="{{ post.link }}"' +
+        'disqus-category-id="{{ post.catId }}"' +
+        'disqus-disable-mobile="false"' +
+        'disqus-config-language="{{ post.lang }}"' +
+        'ready-to-bind="{{ loaded }}">' +
+        '</dir-disqus>';
 
         inject(function($compile, $rootScope) {
             //create a scope and populate it
@@ -25,7 +25,7 @@ xdescribe('dirDiqus directive', function() {
                 title: 'test title',
                 link: 'http://www.test.com',
                 catId: 999,
-				lang: 'en'
+                lang: 'en'
             };
             scope.loaded = false;
 
@@ -52,7 +52,7 @@ xdescribe('dirDiqus directive', function() {
         expect(window.disqus_url).toBeFalsy();
         expect(window.disqus_category_id).toBeFalsy();
         expect(window.disqus_disable_mobile).toBeFalsy();
-        expect(window.disqus_config();window.language).toBeFalsy();
+        expect(window.language).toBeFalsy();
     });
 
     it('should activate when ready to bind is true', function() {
@@ -65,6 +65,7 @@ xdescribe('dirDiqus directive', function() {
         expect(window.disqus_url).toEqual('http://www.test.com');
         expect(window.disqus_category_id).toEqual('999');
         expect(window.disqus_disable_mobile).toEqual('false');
-        expect(window.disqus_config();window.language).toEqual('en');
+        window.disqus_config();
+        expect(window.language).toEqual('en');
     });
 });


### PR DESCRIPTION
Added multi-language support for Disqus, updated test file for it. If the language field is blank then disqus will load the default language which is defined in Disqus administration panel. Example usage in an angular view file:

```html
<dir-disqus disqus-shortname="YOUR_DISQUS_SHORTNAME"
         disqus-identifier="{{ identifier }}"
         disqus-url="{{ url }}"
         disqus-config-language="{{ lang }}">
</dir-disqus>
```