### PR TITLE
Inline Template Attributed Added

### DIFF
--- a/src/directives/pagination/README.md
+++ b/src/directives/pagination/README.md
@@ -87,13 +87,14 @@ And finally include the pagination itself.
     [boundary-links=""]
     [on-page-change=""]
     [pagination-id=""]
-    [template-url=""]>
+    [template-url=""]
+    [inline-template="">
     </dir-pagination-controls>
 ```
 
 ### Specifying The Template
 
-There are two ways to specify the template of the pagination controls directive:
+There are three ways to specify the template of the pagination controls directive:
 
 **1. Use the `paginationTemplateProvider` in your app's config block to set a global template for your app:**
 
@@ -107,6 +108,12 @@ myApp.config(function(paginationTemplateProvider) {
 
 ```HTML
 <dir-pagination-controls template-url="path/to/dirPagination.tpl.html"></dir-pagination-controls>
+```
+
+**3. Use the `inline-template` attribute on each pagination controls directive:**
+
+```HTML
+<dir-pagination-controls inline-template="true"></dir-pagination-controls>
 ```
 
 ## Directives API

--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -227,23 +227,8 @@
         };
 
         if (attrs.inlineTemplate) {
-            var templateAsString = '<ul class="pagination" ng-if="1 < pages.length"> \
-                        <li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 }"> \
-                            <a href="" ng-click="setCurrent(1)">&laquo;</a> \
-                        </li> \
-                        <li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 }"> \
-                            <a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a> \
-                        </li> \
-                        <li ng-repeat="pageNumber in pages track by $index" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' }"> \
-                            <a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a> \
-                        </li> \
-                        <li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }"> \
-                            <a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a> \
-                        </li> \
-                        <li ng-if="boundaryLinks"  ng-class="{ disabled : pagination.current == pagination.last }"> \
-                            <a href="" ng-click="setCurrent(pagination.last)">&raquo;</a> \
-                        </li> \
-                    </ul>';
+            var templateAsString = '<ul class="pagination" ng-if="1 < pages.length"><li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(1)">&laquo;</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a></li><li ng-repeat="pageNumber in pages track by $index" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' }"><a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a></li><li ng-if="boundaryLinks"  ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.last)">&raquo;</a></li></ul>';
+            
             directiveObject = {
                 restrict: 'AE',
                 template: templateAsString,

--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -212,18 +212,50 @@
 
         var numberRegex = /^\d+$/;
 
-        return {
+        //default behavior
+        var directiveObject = {
             restrict: 'AE',
             templateUrl: function(elem, attrs) {
                 return attrs.templateUrl || paginationTemplate.getPath();
             },
             scope: {
                 maxSize: '=?',
-                onPageChange: '&?',
-                paginationId: '=?'
+                    onPageChange: '&?',
+                    paginationId: '=?'
             },
             link: dirPaginationControlsLinkFn
         };
+
+        if (attrs.inlineTemplate) {
+            var templateAsString = '<ul class="pagination" ng-if="1 < pages.length"> \
+                        <li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 }"> \
+                            <a href="" ng-click="setCurrent(1)">&laquo;</a> \
+                        </li> \
+                        <li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 }"> \
+                            <a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a> \
+                        </li> \
+                        <li ng-repeat="pageNumber in pages track by $index" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' }"> \
+                            <a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a> \
+                        </li> \
+                        <li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }"> \
+                            <a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a> \
+                        </li> \
+                        <li ng-if="boundaryLinks"  ng-class="{ disabled : pagination.current == pagination.last }"> \
+                            <a href="" ng-click="setCurrent(pagination.last)">&raquo;</a> \
+                        </li> \
+                    </ul>';
+            directiveObject = {
+                restrict: 'AE',
+                template: templateAsString,
+                scope: {
+                    maxSize: '=?',
+                    onPageChange: '&?',
+                    paginationId: '=?'
+                },
+                link: dirPaginationControlsLinkFn
+            };
+        }
+        return directiveObject;
 
         function dirPaginationControlsLinkFn(scope, element, attrs) {
 


### PR DESCRIPTION
Added a new attribute to the pagination directive controls to allow the user to use the inline template instead of a url.  I was having a hard time finding where exactly to put the template and if the user doesn't want to implement their own custom template then it is easier to use this inline template.

If you need me to add some unit tests I could do that but I hope my change is pretty straight forward.  Please let me know if you have any questions.

Thanks,
Paul