### PR TITLE
Consider assignments in ng-repeat expressions

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -56,7 +56,7 @@
             // regex taken directly from https://github.com/angular/angular.js/blob/master/src/ng/directive/ngRepeat.js#L211
             var match = expression.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?\s*$/);
 
-            var filterPattern = /\|\s*itemsPerPage\s*:[^|]*/;
+            var filterPattern = /\|\s*itemsPerPage\s*:[^|\)]*/;
             if (match[2].match(filterPattern) === null) {
                 throw 'pagination directive: the \'itemsPerPage\' filter must be set.';
             }


### PR DESCRIPTION
This patch takes expressions like the following into account:

```
dir-paginate="item in filteredItems = (items | myFilter:searchValue | itemsPerPage:10)"
```
Without the fix the parenthesis at the end gets removed creating an invalid expression.