### PR TITLE
auto-hide parameter for dir-pagination-controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,11 @@ pip-log.txt
 .idea/
 node_modules/
 vendor/
+
+
+#############
+## Sublime Text
+#############
+
+*.sublime-project
+*.sublime-workspace

--- a/src/directives/pagination/README.md
+++ b/src/directives/pagination/README.md
@@ -87,7 +87,8 @@ And finally include the pagination itself.
     [boundary-links=""]
     [on-page-change=""]
     [pagination-id=""]
-    [template-url=""]>
+    [template-url=""]
+    [auto-hide=""]>
     </dir-pagination-controls>
 ```
 
@@ -164,7 +165,9 @@ i.e. `<dir-pagination-controls on-page-change="myMethod(newPageNumber)">`, and t
 * **`pagination-id`** (optional) Used to group together the dir-pagination-controls with a corresponding dir-paginate when you need more than
 one pagination instance per page. See the section below on setting up multiple instances.
 
-* **`template-url`**  (optional, default = `directives/pagination/dirPagination.tpl.html`) Specifies the template to use.
+* **`template-url`** (optional, default = `directives/pagination/dirPagination.tpl.html`) Specifies the template to use.
+
+* **`auto-hide`** (optional, default = true) Specify whether the dir-pagination-controls should be hidden when there's not enough elements to paginate over.
 
 Note: you cannot use the `dir-pagination-controls` directive without `dir-paginate`. Attempting to do so will result in an
 exception.
@@ -357,7 +360,7 @@ you'll get some nice styling for free. If you don't use Bootstrap, it's simple t
 ## Contribution
 
 Pull requests are welcome. If you are adding a new feature or fixing an as-yet-untested use case, please consider
-writing unit tests to cover your change(s). All unit tests are contained in the `dirPagination.spec.js` file, and 
+writing unit tests to cover your change(s). All unit tests are contained in the `dirPagination.spec.js` file, and
 Karma is set up if you run `grunt watch` as you make changes.
 
 At a minimum, make sure that all the tests still pass. Thanks!

--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -210,7 +210,7 @@
     }
 
     function dirPaginationControlsTemplateInstaller($templateCache) {
-        $templateCache.put('angularUtils.directives.dirPagination.template', '<ul class="pagination" ng-if="1 < pages.length"><li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(1)">&laquo;</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a></li><li ng-repeat="pageNumber in pages track by $index" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' }"><a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a></li><li ng-if="boundaryLinks"  ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.last)">&raquo;</a></li></ul>');
+        $templateCache.put('angularUtils.directives.dirPagination.template', '<ul class="pagination" ng-if="1 < pages.length || !autoHide"><li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(1)">&laquo;</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a></li><li ng-repeat="pageNumber in pages track by $index" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' || ( ! autoHide && pages.length === 1 ) }"><a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a></li><li ng-if="boundaryLinks"  ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.last)">&raquo;</a></li></ul>');
     }
 
     function dirPaginationControlsDirective(paginationService, paginationTemplate) {
@@ -225,7 +225,8 @@
             scope: {
                 maxSize: '=?',
                 onPageChange: '&?',
-                paginationId: '=?'
+                paginationId: '=?',
+                autoHide: '=?'
             },
             link: dirPaginationControlsLinkFn
         };
@@ -244,6 +245,7 @@
             }
 
             if (!scope.maxSize) { scope.maxSize = 9; }
+            scope.autoHide = scope.autoHide === undefined ? true : scope.autoHide;
             scope.directionLinks = angular.isDefined(attrs.directionLinks) ? scope.$parent.$eval(attrs.directionLinks) : true;
             scope.boundaryLinks = angular.isDefined(attrs.boundaryLinks) ? scope.$parent.$eval(attrs.boundaryLinks) : false;
 

--- a/src/directives/pagination/dirPagination.spec.js
+++ b/src/directives/pagination/dirPagination.spec.js
@@ -478,6 +478,56 @@ describe('dirPagination directive', function() {
                     expect(listItems.length).toEqual(100);
                 });
             });
+
+            describe('auto-hide attribute', function () {
+                function compileWithAttributesAndItemsPerPage(attributes, itemsPerPage) {
+                    $scope.collection = myCollection;
+                    $scope.currentPage = 1;
+                    var html = '<ul class="list"><li dir-paginate="item in collection | itemsPerPage: ' +
+                        itemsPerPage + '" current-page="currentPage">{{ item }}</li></ul> ' +
+                        '<dir-pagination-controls ' + attributes + ' ></dir-pagination-controls>';
+                    containingElement.append($compile(html)($scope));
+                    $scope.$apply();
+                }
+
+                it('when not set, should not generate pagination controls, with not enough items to paginate over', function () {
+                    compileWithAttributesAndItemsPerPage('', 100);
+                    var pagination = containingElement.find('ul.pagination');
+                    expect(pagination.length).toEqual(0);
+                });
+
+                it('when not set, should generate pagination controls, with enough items to paginate over', function () {
+                    compileWithAttributesAndItemsPerPage('', 99);
+                    var pagination = containingElement.find('ul.pagination');
+                    expect(pagination.length).toEqual(1);
+                });
+
+                it('when set to false, should generate pagination controls, with not enough items to paginate over', function () {
+                    compileWithAttributesAndItemsPerPage('auto-hide="false"', 100);
+                    var pagination = containingElement.find('ul.pagination');
+                    expect(pagination.length).toEqual(1);
+                    var pageLinks = containingElement.find('ul.pagination li.disabled');
+                    expect(pageLinks.length).toEqual(3);
+                });
+
+                it('when set to false, should generate pagination controls, with enough items to paginate over', function () {
+                    compileWithAttributesAndItemsPerPage('auto-hide="false"', 99);
+                    var pagination = containingElement.find('ul.pagination');
+                    expect(pagination.length).toEqual(1);
+                });
+
+                it('when set to true, should generate pagination controls, with enough items to paginate over', function () {
+                    compileWithAttributesAndItemsPerPage('auto-hide="true"', 100);
+                    var pagination = containingElement.find('ul.pagination');
+                    expect(pagination.length).toEqual(0);
+                });
+
+                it('when set to true, should generate pagination controls, with not enough items to paginate over', function () {
+                    compileWithAttributesAndItemsPerPage('auto-hide="true"', 99);
+                    var pagination = containingElement.find('ul.pagination');
+                    expect(pagination.length).toEqual(1);
+                });
+            });
         });
 
     });


### PR DESCRIPTION
An optional auto-hide parameter, with default value set to true, thus maintaining backward compatibility.

Fixes #165.