### PR TITLE
Warn if pagination directive not found when controls are linked, but …

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -241,7 +241,7 @@
 
             if (!paginationService.isRegistered(paginationId) && !paginationService.isRegistered(rawId)) {
                 var idMessage = (paginationId !== DEFAULT_ID) ? ' (id: ' + paginationId + ') ' : ' ';
-                console.log('WARNING - pagination directive: the pagination controls' + idMessage + 'cannot be used without the corresponding pagination directive, which was not found at link time.');
+                console.warn('Pagination directive: the pagination controls' + idMessage + 'cannot be used without the corresponding pagination directive, which was not found at link time.');
             }
 
             if (!scope.maxSize) { scope.maxSize = 9; }

--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -241,7 +241,7 @@
 
             if (!paginationService.isRegistered(paginationId) && !paginationService.isRegistered(rawId)) {
                 var idMessage = (paginationId !== DEFAULT_ID) ? ' (id: ' + paginationId + ') ' : ' ';
-                throw 'pagination directive: the pagination controls' + idMessage + 'cannot be used without the corresponding pagination directive.';
+                console.log('WARNING - pagination directive: the pagination controls' + idMessage + 'cannot be used without the corresponding pagination directive, which was not found at link time.');
             }
 
             if (!scope.maxSize) { scope.maxSize = 9; }
@@ -262,7 +262,9 @@
             };
 
             scope.$watch(function() {
-                return (paginationService.getCollectionLength(paginationId) + 1) * paginationService.getItemsPerPage(paginationId);
+                if (paginationService.isRegistered(paginationId)) {
+                    return (paginationService.getCollectionLength(paginationId) + 1) * paginationService.getItemsPerPage(paginationId);
+                }
             }, function(length) {
                 if (0 < length) {
                     generatePagination();
@@ -270,7 +272,9 @@
             });
 
             scope.$watch(function() {
-                return (paginationService.getItemsPerPage(paginationId));
+                if (paginationService.isRegistered(paginationId)) {
+                    return (paginationService.getItemsPerPage(paginationId));
+                }
             }, function(current, previous) {
                 if (current != previous && typeof previous !== 'undefined') {
                     goToPage(scope.pagination.current);
@@ -278,7 +282,9 @@
             });
 
             scope.$watch(function() {
-                return paginationService.getCurrentPage(paginationId);
+                if (paginationService.isRegistered(paginationId)) {
+                    return paginationService.getCurrentPage(paginationId);
+                }
             }, function(currentPage, previousPage) {
                 if (currentPage != previousPage) {
                     goToPage(currentPage);
@@ -286,14 +292,14 @@
             });
 
             scope.setCurrent = function(num) {
-                if (isValidPageNumber(num)) {
+                if (paginationService.isRegistered(paginationId) && isValidPageNumber(num)) {
                     num = parseInt(num, 10);
                     paginationService.setCurrentPage(paginationId, num);
                 }
             };
 
             function goToPage(num) {
-                if (isValidPageNumber(num)) {
+                if (paginationService.isRegistered(paginationId) && isValidPageNumber(num)) {
                     scope.pages = generatePagesArray(num, paginationService.getCollectionLength(paginationId), paginationService.getItemsPerPage(paginationId), paginationRange);
                     scope.pagination.current = num;
                     updateRangeValues();
@@ -306,15 +312,16 @@
             }
 
             function generatePagination() {
-                var page = parseInt(paginationService.getCurrentPage(paginationId)) || 1;
-
-                scope.pages = generatePagesArray(page, paginationService.getCollectionLength(paginationId), paginationService.getItemsPerPage(paginationId), paginationRange);
-                scope.pagination.current = page;
-                scope.pagination.last = scope.pages[scope.pages.length - 1];
-                if (scope.pagination.last < scope.pagination.current) {
-                    scope.setCurrent(scope.pagination.last);
-                } else {
-                    updateRangeValues();
+                if (paginationService.isRegistered(paginationId)) {
+                    var page = parseInt(paginationService.getCurrentPage(paginationId)) || 1;
+                    scope.pages = generatePagesArray(page, paginationService.getCollectionLength(paginationId), paginationService.getItemsPerPage(paginationId), paginationRange);
+                    scope.pagination.current = page;
+                    scope.pagination.last = scope.pages[scope.pages.length - 1];
+                    if (scope.pagination.last < scope.pagination.current) {
+                        scope.setCurrent(scope.pagination.last);
+                    } else {
+                        updateRangeValues();
+                    }
                 }
             }
 
@@ -323,15 +330,16 @@
              * template to display the current page range, e.g. "showing 21 - 40 of 144 results";
              */
             function updateRangeValues() {
-                var currentPage = paginationService.getCurrentPage(paginationId),
-                    itemsPerPage = paginationService.getItemsPerPage(paginationId),
-                    totalItems = paginationService.getCollectionLength(paginationId);
+                if (paginationService.isRegistered(paginationId)) {
+                    var currentPage = paginationService.getCurrentPage(paginationId),
+                        itemsPerPage = paginationService.getItemsPerPage(paginationId),
+                        totalItems = paginationService.getCollectionLength(paginationId);
 
-                scope.range.lower = (currentPage - 1) * itemsPerPage + 1;
-                scope.range.upper = Math.min(currentPage * itemsPerPage, totalItems);
-                scope.range.total = totalItems;
+                    scope.range.lower = (currentPage - 1) * itemsPerPage + 1;
+                    scope.range.upper = Math.min(currentPage * itemsPerPage, totalItems);
+                    scope.range.total = totalItems;
+                }
             }
-
             function isValidPageNumber(num) {
                 return (numberRegex.test(num) && (0 < num && num <= scope.pagination.last));
             }

--- a/src/directives/pagination/dirPagination.spec.js
+++ b/src/directives/pagination/dirPagination.spec.js
@@ -209,14 +209,21 @@ describe('dirPagination directive', function() {
 
     describe('pagination controls', function() {
 
-        it('should throw an exception if the dir-paginate directive has not been set up', function() {
+        beforeEach(function(){
+            spyOn(console, 'log').and.callThrough();
+        });
+
+        it('should throw a warning if the dir-paginate directive has not been set up', function() {
+
             function compile() {
                 var html = '<dir-pagination-controls></dir-pagination-controls>';
                 containingElement.append($compile(html)($scope));
                 $scope.$apply();
             }
 
-            expect(compile).toThrow("pagination directive: the pagination controls cannot be used without the corresponding pagination directive.");
+            compile();
+
+            expect(console.log).toHaveBeenCalledWith('WARNING - pagination directive: the pagination controls cannot be used without the corresponding pagination directive, which was not found at link time.');
         });
 
         it('should not display pagination if all rows fit on one page', function() {
@@ -552,6 +559,7 @@ describe('dirPagination directive', function() {
                 collection1.push('c1:' + i);
                 collection2.push('c2:' + i);
             }
+            spyOn(console, 'log').and.callThrough();
         });
 
         /**
@@ -663,7 +671,7 @@ describe('dirPagination directive', function() {
             expect(getMultiListItems("c2")).toEqual(['c2:6', 'c2:7']);
         });
 
-        it('should throw an exception if a non-existant paginationId is set in the pagination-controls', function() {
+        it('should print a warning if a non-existant paginationId is set in the pagination-controls', function() {
             $scope.collection = [1,2,3,4,5];
 
             function compile() {
@@ -673,8 +681,8 @@ describe('dirPagination directive', function() {
                 containingElement.append($compile(html)($scope));
                 $scope.$apply();
             }
-
-            expect(compile).toThrow("pagination directive: the pagination controls (id: id2) cannot be used without the corresponding pagination directive.");
+            compile();
+            expect(console.log).toHaveBeenCalledWith('WARNING - pagination directive: the pagination controls (id: id2) cannot be used without the corresponding pagination directive, which was not found at link time.');
         });
 
         it('should throw an exception if a non-existant paginationId is set in the itemsPerPage filter', function() {

--- a/src/directives/pagination/dirPagination.spec.js
+++ b/src/directives/pagination/dirPagination.spec.js
@@ -210,7 +210,7 @@ describe('dirPagination directive', function() {
     describe('pagination controls', function() {
 
         beforeEach(function(){
-            spyOn(console, 'log').and.callThrough();
+            spyOn(console, 'warn').and.callThrough();
         });
 
         it('should throw a warning if the dir-paginate directive has not been set up', function() {
@@ -223,7 +223,7 @@ describe('dirPagination directive', function() {
 
             compile();
 
-            expect(console.log).toHaveBeenCalledWith('WARNING - pagination directive: the pagination controls cannot be used without the corresponding pagination directive, which was not found at link time.');
+            expect(console.warn).toHaveBeenCalledWith('Pagination directive: the pagination controls cannot be used without the corresponding pagination directive, which was not found at link time.');
         });
 
         it('should not display pagination if all rows fit on one page', function() {
@@ -559,7 +559,7 @@ describe('dirPagination directive', function() {
                 collection1.push('c1:' + i);
                 collection2.push('c2:' + i);
             }
-            spyOn(console, 'log').and.callThrough();
+            spyOn(console, 'warn').and.callThrough();
         });
 
         /**
@@ -682,7 +682,7 @@ describe('dirPagination directive', function() {
                 $scope.$apply();
             }
             compile();
-            expect(console.log).toHaveBeenCalledWith('WARNING - pagination directive: the pagination controls (id: id2) cannot be used without the corresponding pagination directive, which was not found at link time.');
+            expect(console.warn).toHaveBeenCalledWith('Pagination directive: the pagination controls (id: id2) cannot be used without the corresponding pagination directive, which was not found at link time.');
         });
 
         it('should throw an exception if a non-existant paginationId is set in the itemsPerPage filter', function() {


### PR DESCRIPTION
…do not throw error

This pull request resolves #169 by not throwing an error if the `dir-pagination-controls` directive does not detect a corresponding `dir-paginate` when it is linked. Instead, if such a directve is not found then `dir-pagination-controls` will print an error to the console and check whether the corresponding directive is registered later on in other functions. It is possibly not the most elegant solution to this problem but seems to work in my case. I've also altered the unit tests to match.