### PR TITLE
Replace hard-coded value with usersPerPage variable defined in controller

### DIFF
--- a/src/directives/pagination/README.md
+++ b/src/directives/pagination/README.md
@@ -346,7 +346,7 @@ potential advantage of being triggered whenever the current-page changes, rather
 ```HTML
 <div ng-controller="UsersController">
     <table>
-        <tr dir-paginate="user in users | itemsPerPage: 25" total-items="totalUsers" current-page="pagination.current">
+        <tr dir-paginate="user in users | itemsPerPage: usersPerPage" total-items="totalUsers" current-page="pagination.current">
             <td>{{ user.name }}</td>
             <td>{{ user.email }}</td>
         </tr>


### PR DESCRIPTION
I noticed that the README [asynchronous data example](https://github.com/michaelbromley/angularUtils/tree/master/src/directives/pagination#example-asynchronous-setup) sets an unused `$scope.usersPerPage` in the controller.