### PR TITLE
Added property dir-disabled to dir-pagination-controls

### DIFF
--- a/src/directives/pagination/README.md
+++ b/src/directives/pagination/README.md
@@ -174,6 +174,8 @@ one pagination instance per page. See the section below on setting up multiple i
 
 * **`auto-hide`** (optional, default = true) Specify whether the dir-pagination-controls should be hidden when there's not enough elements to paginate over.
 
+* **`dir-disabled ** Specify whether the dir-pagination-controls should be disabled, for example, when fetching data from remote server.
+
 Note: you cannot use the `dir-pagination-controls` directive without `dir-paginate`. Attempting to do so will result in an
 exception.
 

--- a/src/directives/pagination/README.md
+++ b/src/directives/pagination/README.md
@@ -174,7 +174,7 @@ one pagination instance per page. See the section below on setting up multiple i
 
 * **`auto-hide`** (optional, default = true) Specify whether the dir-pagination-controls should be hidden when there's not enough elements to paginate over.
 
-* **`dir-disabled ** Specify whether the dir-pagination-controls should be disabled, for example, when fetching data from remote server.
+* **`dir-disabled` ** Specify whether the dir-pagination-controls should be disabled, for example, when fetching data from remote server.
 
 Note: you cannot use the `dir-pagination-controls` directive without `dir-paginate`. Attempting to do so will result in an
 exception.

--- a/src/directives/pagination/README.md
+++ b/src/directives/pagination/README.md
@@ -174,7 +174,7 @@ one pagination instance per page. See the section below on setting up multiple i
 
 * **`auto-hide`** (optional, default = true) Specify whether the dir-pagination-controls should be hidden when there's not enough elements to paginate over.
 
-* **`dir-disabled` ** Specify whether the dir-pagination-controls should be disabled, for example, when fetching data from remote server.
+* **`dir-disabled`** Specify whether the dir-pagination-controls should be disabled, for example, when fetching data from remote server.
 
 Note: you cannot use the `dir-pagination-controls` directive without `dir-paginate`. Attempting to do so will result in an
 exception.

--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -210,7 +210,7 @@
     }
 
     function dirPaginationControlsTemplateInstaller($templateCache) {
-        $templateCache.put('angularUtils.directives.dirPagination.template', '<ul class="pagination" ng-if="1 < pages.length || !autoHide"><li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(1)">&laquo;</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 }"><a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a></li><li ng-repeat="pageNumber in pages track by tracker(pageNumber, $index)" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' || ( ! autoHide && pages.length === 1 ) }"><a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a></li><li ng-if="boundaryLinks"  ng-class="{ disabled : pagination.current == pagination.last }"><a href="" ng-click="setCurrent(pagination.last)">&raquo;</a></li></ul>');
+        $templateCache.put('angularUtils.directives.dirPagination.template', '<ul class="pagination" ng-if="1 < pages.length || !autoHide"><li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == 1 || dirDisabled }"><a href="" ng-click="setCurrent(1)">&laquo;</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == 1 || dirDisabled }"><a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a></li><li ng-repeat="pageNumber in pages track by tracker(pageNumber, $index)" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == \'...\' || ( ! autoHide && pages.length === 1 ) || dirDisabled }"><a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a></li><li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last || dirDisabled }"><a href="" ng-click="setCurrent(pagination.current + 1)">&rsaquo;</a></li><li ng-if="boundaryLinks" ng-class="{ disabled : pagination.current == pagination.last || dirDisabled }"><a href="" ng-click="setCurrent(pagination.last)">&raquo;</a></li></ul>');
     }
 
     function dirPaginationControlsDirective(paginationService, paginationTemplate) {
@@ -224,6 +224,7 @@
             },
             scope: {
                 maxSize: '=?',
+                dirDisabled: '=?',
                 onPageChange: '&?',
                 paginationId: '=?',
                 autoHide: '=?'
@@ -292,7 +293,7 @@
             });
 
             scope.setCurrent = function(num) {
-                if (paginationService.isRegistered(paginationId) && isValidPageNumber(num)) {
+                if (paginationService.isRegistered(paginationId) && isValidPageNumber(num) && !scope.dirDisabled) {
                     num = parseInt(num, 10);
                     paginationService.setCurrentPage(paginationId, num);
                 }


### PR DESCRIPTION
When fetching data from a remote server, the pagination controls are still active. If the control is bound with the fetch function, the user can fetch data more than once while the first data didn't arrive.

So this new property will help in those cases, managing when the control will set the current page and call the callback.

The use is simple, considering the controller has a variable to control when the client is waiting called 'loading', the code would be like this:

<pre>
&lt;/dir-pagination-controls dir-disabled="loading"&gt;&lt;/dir-pagination-controls&gt;
</pre>

Hope it helps. Any suggestions are welcome.