### PR TITLE
Declare pagination module without try-catch

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -25,13 +25,7 @@
     /**
      * Module
      */
-    var module;
-    try {
-        module = angular.module(moduleName);
-    } catch(err) {
-        // named module does not exist, so create one
-        module = angular.module(moduleName, []);
-    }
+    var module = angular.module(moduleName, []);
 
     module
         .directive('dirPaginate', ['$compile', '$parse', 'paginationService', dirPaginateDirective])


### PR DESCRIPTION
Prevent "Duplicate Reference" error in angular by declaring module outside of try-catch