### PR TITLE
uiBreadcrumbs: Copy state locals to proxy state

### DIFF
--- a/src/directives/uiBreadcrumbs/uiBreadcrumbs.js
+++ b/src/directives/uiBreadcrumbs/uiBreadcrumbs.js
@@ -87,7 +87,8 @@
                             if (typeof scope.abstractProxyProperty !== 'undefined') {
                                 proxyStateName = getObjectValue(scope.abstractProxyProperty, currentState);
                                 if (proxyStateName) {
-                                    workingState = $state.get(proxyStateName);
+                                    workingState = angular.copy($state.get(proxyStateName));
+                                    workingState.locals = currentState.locals;
                                 } else {
                                     workingState = false;
                                 }

--- a/src/directives/uiBreadcrumbs/uiBreadcrumbs.js
+++ b/src/directives/uiBreadcrumbs/uiBreadcrumbs.js
@@ -88,7 +88,9 @@
                                 proxyStateName = getObjectValue(scope.abstractProxyProperty, currentState);
                                 if (proxyStateName) {
                                     workingState = angular.copy($state.get(proxyStateName));
-                                    workingState.locals = currentState.locals;
+                                    if (workingState) {
+                                        workingState.locals = currentState.locals;
+                                    }
                                 } else {
                                     workingState = false;
                                 }

--- a/src/directives/uiBreadcrumbs/uiBreadcrumbs.spec.js
+++ b/src/directives/uiBreadcrumbs/uiBreadcrumbs.spec.js
@@ -96,6 +96,30 @@ describe('uiBreadcrumbs directive', function() {
                         data: {
                             displayName: 'A Thing'
                         }
+                    })
+                    .state( 'root.project', {
+                        abstract: true,
+                        url: 'abstract2/',
+                        data: {
+                            breadcrumbProxy: 'root.project.dashboard'
+                        },
+                        resolve: {
+                            resolvedName: function(){
+                                return "Project";
+                            }
+                        }
+                    })
+                    .state( 'root.project.dashboard', {
+                        url: 'dashboard/',
+                        data: {
+                            displayName: '{{ resolvedName }} Dashboard'
+                        }
+                    })
+                    .state( 'root.project.tasks', {
+                        url: 'list/',
+                        data: {
+                            displayName: '{{ resolvedName }} Tasks'
+                        }
                     });
             });
         module('mockModule');
@@ -234,6 +258,18 @@ describe('uiBreadcrumbs directive', function() {
         expect(element2[0].querySelectorAll('li')[1].innerHTML).toContain('Things');
         expect(element2[0].querySelectorAll('li')[2]).not.toBeDefined();
         expect(element2[0].querySelectorAll('li').length).toBe(2);
+    });
+
+    it('should use resolved variables for abstract state proxy', function() {
+        var element2 = $compile('<ui-breadcrumbs displayname-property="data.displayName" abstract-proxy-property="data.breadcrumbProxy"></ui-breadcrumbs>')($scope);
+        $state.go('root.project.tasks');
+        $scope.$apply();
+
+        expect(element2[0].querySelectorAll('li')[0].innerHTML).toContain('Home');
+        expect(element2[0].querySelectorAll('li')[1].innerHTML).toContain('Project Dashboard');
+        expect(element2[0].querySelectorAll('li')[2].innerHTML).toContain('Project Tasks');
+        expect(element2[0].querySelectorAll('li')[3]).not.toBeDefined();
+        expect(element2[0].querySelectorAll('li').length).toBe(3);
     });
 
 });


### PR DESCRIPTION
This is the reworked version of https://github.com/michaelbromley/angularUtils-uiBreadcrumbs/pull/2 with tests added.

I think this solves some common problems including #261. There is one gotcha, though: The resolve variables need to be declared for the abstract state or one of its parent states. That is because the state used as the proxy usually is not part of the active state chain and therefore has no own variables resolved. Example:

```JavaScript
.state( 'root.project', {
    abstract: true,
    url: 'abstract2/',
    data: {
        breadcrumbProxy: 'root.project.dashboard'
    },
    resolve: {
        resolvedName: function(){
            return "Project";
        }
    }
})
.state( 'root.project.dashboard', {
    url: 'dashboard/',
    data: {
        displayName: '{{ resolvedName }} Dashboard'
    }
})
.state( 'root.project.tasks', {
    url: 'list/',
    data: {
        displayName: '{{ resolvedName }} Tasks'
    }
})
```

Note that the resolve is applied to `root.project`, not `root.project.dashboard`. The alternative to the fix / workaround provided with this pull request would be to actually trigger a resolve for the `root.project.dashboard` variables. But I a) couldn't figure out how to do this and b) this wasn't worth the effort in my case since applying the resolve to the abstract state can be easily done and solves most if not all of the issues without introducing additional complexity to the code.