### PR TITLE
Fix pagination when using an object with dir-paginate

### DIFF
--- a/src/directives/pagination/dirPagination.js
+++ b/src/directives/pagination/dirPagination.js
@@ -93,7 +93,8 @@
                         return collectionGetter(scope);
                     }, function(collection) {
                         if (collection) {
-                            paginationService.setCollectionLength(paginationId, collection.length);
+                            var collectionLength = (collection instanceof Array) ? collection.length : Object.keys(collection).length;
+                            paginationService.setCollectionLength(paginationId, collectionLength);
                         }
                     });
                 }


### PR DESCRIPTION
When using an object with dir-paginate the pagination was not getting a valid length, so no numbers where shown within the pagination template.

The new code now checks to see if the collection is an array or object, and correctly returns the length.

I've also tested this in a clean Angular JS project to confirm the issue and the fix.

Thanks!