### PR TITLE
readyToBind fix

### DIFF
--- a/src/directives/disqus/dirDisqus.js
+++ b/src/directives/disqus/dirDisqus.js
@@ -6,7 +6,7 @@
  * Available under the MIT license.
  */
 
-(function() {
+(function () {
 
     /**
      * Config
@@ -19,29 +19,29 @@
     var module;
     try {
         module = angular.module(moduleName);
-    } catch(err) {
+    } catch (err) {
         // named module does not exist, so create one
         module = angular.module(moduleName, []);
     }
 
-    module.directive('dirDisqus', ['$window', function($window) {
+    module.directive('dirDisqus', ['$window', function ($window) {
         return {
             restrict: 'E',
             scope: {
                 disqus_shortname: '@disqusShortname',
                 disqus_identifier: '@disqusIdentifier',
-                disqus_title: '@disqusTitle',
                 disqus_url: '@disqusUrl',
+                disqus_title: '@disqusTitle',
                 disqus_category_id: '@disqusCategoryId',
                 disqus_disable_mobile: '@disqusDisableMobile',
-                disqus_config_language : '@disqusConfigLanguage',
-                disqus_remote_auth_s3 : '@disqusRemoteAuthS3',
-                disqus_api_key : '@disqusApiKey',
+                disqus_config_language: '@disqusConfigLanguage',
+                disqus_remote_auth_s3: '@disqusRemoteAuthS3',
+                disqus_api_key: '@disqusApiKey',
                 disqus_on_ready: "&disqusOnReady",
                 readyToBind: "@"
             },
             template: '<div id="disqus_thread"></div><a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>',
-            link: function(scope) {
+            link: function (scope) {
 
                 // ensure that the disqus_identifier and disqus_url are both set, otherwise we will run in to identifier conflicts when using URLs with "#" in them
                 // see http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-
@@ -49,23 +49,23 @@
                     throw "Please ensure that the `disqus-identifier` and `disqus-url` attributes are both set.";
                 }
 
-                scope.$watch("readyToBind", function(isReady) {
+                scope.$watch("readyToBind", function (loadedOn) {
 
                     // If the directive has been called without the 'ready-to-bind' attribute, we
-                    // set the default to "true" so that Disqus will be loaded straight away.
-                    if ( !angular.isDefined( isReady ) ) {
-                        isReady = "true";
+                    // set a default value so that Disqus will be loaded straight away.
+                    if (!angular.isDefined(loadedOn)) {
+                        loadedOn = new Date();
                     }
-                    if (scope.$eval(isReady)) {
-                        console.log('remote'+scope.disqus_remote_auth_s3);
+                    var isReady = typeof scope.$eval(loadedOn) !== 'undefined';
+                    if (isReady) {
                         // put the config variables into separate global vars so that the Disqus script can see them
                         $window.disqus_shortname = scope.disqus_shortname;
                         $window.disqus_identifier = scope.disqus_identifier;
-                        $window.disqus_title = scope.disqus_title;
                         $window.disqus_url = scope.disqus_url;
+                        $window.disqus_title = scope.disqus_title;
                         $window.disqus_category_id = scope.disqus_category_id;
                         $window.disqus_disable_mobile = scope.disqus_disable_mobile;
-                        $window.disqus_config =  function () {
+                        $window.disqus_config = function () {
                             this.language = scope.disqus_config_language;
                             this.page.remote_auth_s3 = scope.disqus_remote_auth_s3;
                             this.page.api_key = scope.disqus_api_key;
@@ -88,8 +88,8 @@
                                     this.page.url = scope.disqus_url;
                                     this.page.title = scope.disqus_title;
                                     this.language = scope.disqus_config_language;
-                                    this.page.remote_auth_s3=scope.disqus_remote_auth_s3;
-                                    this.page.api_key=scope.disqus_api_key;
+                                    this.page.remote_auth_s3 = scope.disqus_remote_auth_s3;
+                                    this.page.api_key = scope.disqus_api_key;
                                 }
                             });
                         }


### PR DESCRIPTION
Using boolean for readyToBind wasn't enough for reload, since watch
doesn't get triggered if "loaded = true;" was set on angular's
routeChangeSuccess event (probably because the value actually doesn't
change).

Therefore 'isReady & boolean' was replaced with 'loadedOn / DateTime'
and since on each call there is a new value, readyToBind gets triggered.