### PR TITLE
Single config object instead of separate properties

### DIFF
--- a/src/directives/disqus/README.md
+++ b/src/directives/disqus/README.md
@@ -25,16 +25,23 @@ First, put the directive code in your app, wherever you store your directives.
 
 Wherever you want the Disqus comments to appear, add the following to your template:
 
-```html
-<dir-disqus disqus-shortname="YOUR_DISQUS_SHORTNAME"
-         disqus-identifier="{{ identifier }}"
-         disqus-url="{{ url }}">
-</dir-disqus>
+```
+<dir-disqus config="disqusConfig"></dir-disqus>
+```
+
+And in your controller:
+
+```
+$scope.disqusConfig = {
+	disqus_shortname: 'Your disqus shortname',
+	disqus_identifier: 'Comments identifier',
+	disqus_url: 'Comments url'
+};
 ```
 
 The attributes given above are all required. The inclusion of the identifier and URL ensure that identifier conflicts will not occur. See http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-
 
-If the identifier and URL and not included as attributes, the directive will throw an exception.
+If the identifier and URL and not included as attributes, the directive will not appear.
 
 ## Full API
 
@@ -42,20 +49,19 @@ You can optionally specify the other configuration variables by including the as
 on the directive's element tag. For more information on the available config vars, see the
 [Disqus docs](http://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables).
 
-```HTML
-<dir-disqus disqus-shortname="YOUR_DISQUS_SHORTNAME"
-            disqus-identifier="{{ post.ID }}"
-            disqus-title="{{ post.title }}"
-            disqus-url="{{ post.link }}"
-            disqus-category-id="{{ post.catId }}"
-            disqus-disable-mobile="false"
-            disqus-config-language="{{ post.lang }}"
-            disqus-remote-auth-s3="{{remote_auth_s3}}"
-            disqus-api-key="{{public_api_key}}"
-            disqus-on-ready="ready()"
-            ready-to-bind="{{ loaded }}"
-            >
-</dir-disqus>
+```
+$scope.disqusConfig = {
+	disqus_shortname: 'Your disqus shortname',
+	disqus_identifier: 'Comments identifier',
+	disqus_url: 'Comments url',
+	disqus_title: 'Comments title',
+	disqus_category_id: 'Comments category id }}',
+	disqus_disable_mobile: 'false',
+	disqus_config_language: 'Comments language',
+	disqus_remote_auth_s3: 'remote_auth_s3',
+	disqus_api_key: 'public_api_key',
+	disqus_on_ready: ready()
+};
 ```
 
 If using the `disqus-config-language` setting, please see [this Disqus article on multi-lingual websites](https://help.disqus.com/customer/portal/articles/466249-multi-lingual-websites)
@@ -65,42 +71,8 @@ for which languages are supported.
 If using the `disqus-remote-auth-s3 and disqus-api-key` setting, please see [Integrating Single Sign-On](https://help.disqus.com/customer/portal/articles/236206#sso-script)
 to know how to generate a remote_auth_s3 and public_api_key.
 
-note:Single Sign-on (SSO) allows users to sign into a site and be able to use Disqus Comments without having to re-authenticate Disqus. SSO will create a site-specific user profile on Disqus, in a way that will prevent conflict with existing Disqus users.
-
-
-## `ready-to-bind` attribute
-
-If you are loading the page asynchronously, the model data (`$scope.article` in the above example) used to populate the config variables above
-will probably not be defined at the time the page is loaded. This will result in your config settings
-being all undefined. To get around this, you can specify a scope variable that should be set to (or evaluate to) `false`
-until your data is loaded, at which point you can set it to `true`. The directive watches this property and once it changes
-to `true`, any config attributes which are bound to your model should be available and used to load up the Disqus widget.
-
-For example:
-
-```JavaScript
-// simple example of controller loading async data
-function myController($scope, $http) {
-    $scope.contentLoaded = false;
-
-    $http.get('api/article/1').then(function(result) {
-        $scope.article = result.article;
-        $scope.contentLoaded = true; // this tells the directive that it should load the Disqus widget now
-    })
-}
-```
-```html
-// in your view code
-<dir-disqus disqus-shortname="YOUR_DISQUS_SHORTNAME"
-            disqus-identifier="{{ article.id }}"
-            disqus-url="{{ article.url }}"
-            ready-to-bind="{{ contentLoaded }}">
-</dir-disqus>
-```
-
-If you omit the `ready-to-bind` attribute, the Disqus widget will be created immediately. This is okay so long as you don't rely on interpolated data which is not available on page load.
+Note: Single Sign-on (SSO) allows users to sign into a site and be able to use Disqus Comments without having to re-authenticate Disqus. SSO will create a site-specific user profile on Disqus, in a way that will prevent conflict with existing Disqus users.
 
 ## `disqus-on-ready` attribute
 
- If Disqus is rendered, `disqus-on-ready` function will be called. Callback is registered to disqus by similar technique
- as explained in [this post](https://help.disqus.com/customer/portal/articles/466258-capturing-disqus-commenting-activity-via-callbacks).
+If Disqus is rendered, `disqus-on-ready` function will be called. Callback is registered to disqus by similar technique as explained in [this post](https://help.disqus.com/customer/portal/articles/466258-capturing-disqus-commenting-activity-via-callbacks).

--- a/src/directives/disqus/dirDisqus.js
+++ b/src/directives/disqus/dirDisqus.js
@@ -6,7 +6,7 @@
  * Available under the MIT license.
  */
 
-(function() {
+(function () {
 
     /**
      * Config
@@ -19,29 +19,29 @@
     var module;
     try {
         module = angular.module(moduleName);
-    } catch(err) {
+    } catch (err) {
         // named module does not exist, so create one
         module = angular.module(moduleName, []);
     }
 
-    module.directive('dirDisqus', ['$window', function($window) {
+    module.directive('dirDisqus', ['$window', function ($window) {
         return {
             restrict: 'E',
             scope: {
                 disqus_shortname: '@disqusShortname',
                 disqus_identifier: '@disqusIdentifier',
-                disqus_title: '@disqusTitle',
                 disqus_url: '@disqusUrl',
+                disqus_title: '@disqusTitle',
                 disqus_category_id: '@disqusCategoryId',
                 disqus_disable_mobile: '@disqusDisableMobile',
-                disqus_config_language : '@disqusConfigLanguage',
-                disqus_remote_auth_s3 : '@disqusRemoteAuthS3',
-                disqus_api_key : '@disqusApiKey',
+                disqus_config_language: '@disqusConfigLanguage',
+                disqus_remote_auth_s3: '@disqusRemoteAuthS3',
+                disqus_api_key: '@disqusApiKey',
                 disqus_on_ready: "&disqusOnReady",
                 readyToBind: "@"
             },
             template: '<div id="disqus_thread"></div><a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>',
-            link: function(scope) {
+            link: function (scope) {
 
                 // ensure that the disqus_identifier and disqus_url are both set, otherwise we will run in to identifier conflicts when using URLs with "#" in them
                 // see http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-
@@ -49,23 +49,23 @@
                     throw "Please ensure that the `disqus-identifier` and `disqus-url` attributes are both set.";
                 }
 
-                scope.$watch("readyToBind", function(isReady) {
+                scope.$watch("readyToBind", function (loadedOn) {
 
                     // If the directive has been called without the 'ready-to-bind' attribute, we
-                    // set the default to "true" so that Disqus will be loaded straight away.
-                    if ( !angular.isDefined( isReady ) ) {
-                        isReady = "true";
+                    // set a default value so that Disqus will be loaded straight away.
+                    if (!angular.isDefined(loadedOn)) {
+                        loadedOn = new Date();
                     }
-                    if (scope.$eval(isReady)) {
-                        console.log('remote'+scope.disqus_remote_auth_s3);
+                    var isReady = typeof scope.$eval(loadedOn) !== 'undefined';
+                    if (isReady) {
                         // put the config variables into separate global vars so that the Disqus script can see them
                         $window.disqus_shortname = scope.disqus_shortname;
                         $window.disqus_identifier = scope.disqus_identifier;
-                        $window.disqus_title = scope.disqus_title;
                         $window.disqus_url = scope.disqus_url;
+                        $window.disqus_title = scope.disqus_title;
                         $window.disqus_category_id = scope.disqus_category_id;
                         $window.disqus_disable_mobile = scope.disqus_disable_mobile;
-                        $window.disqus_config =  function () {
+                        $window.disqus_config = function () {
                             this.language = scope.disqus_config_language;
                             this.page.remote_auth_s3 = scope.disqus_remote_auth_s3;
                             this.page.api_key = scope.disqus_api_key;
@@ -88,8 +88,8 @@
                                     this.page.url = scope.disqus_url;
                                     this.page.title = scope.disqus_title;
                                     this.language = scope.disqus_config_language;
-                                    this.page.remote_auth_s3=scope.disqus_remote_auth_s3;
-                                    this.page.api_key=scope.disqus_api_key;
+                                    this.page.remote_auth_s3 = scope.disqus_remote_auth_s3;
+                                    this.page.api_key = scope.disqus_api_key;
                                 }
                             });
                         }

--- a/src/directives/disqus/dirDisqus.js
+++ b/src/directives/disqus/dirDisqus.js
@@ -1,7 +1,8 @@
-/**
+﻿/**
  * A directive to embed a Disqus comments widget on your AngularJS page.
  *
  * Created by Michael on 22/01/14.
+ * Modified by Serkan "coni2k" Holat on 24/02/16.
  * Copyright Michael Bromley 2014
  * Available under the MIT license.
  */
@@ -28,75 +29,60 @@
         return {
             restrict: 'E',
             scope: {
-                disqus_shortname: '@disqusShortname',
-                disqus_identifier: '@disqusIdentifier',
-                disqus_url: '@disqusUrl',
-                disqus_title: '@disqusTitle',
-                disqus_category_id: '@disqusCategoryId',
-                disqus_disable_mobile: '@disqusDisableMobile',
-                disqus_config_language: '@disqusConfigLanguage',
-                disqus_remote_auth_s3: '@disqusRemoteAuthS3',
-                disqus_api_key: '@disqusApiKey',
-                disqus_on_ready: "&disqusOnReady",
-                readyToBind: "@"
+                config: '='
             },
-            template: '<div id="disqus_thread"></div><a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>',
+            template: '<div id="disqus_thread"></div><a href="http://disqus.com" class="dsq-brlink"></a>',
             link: function (scope) {
 
-                // ensure that the disqus_identifier and disqus_url are both set, otherwise we will run in to identifier conflicts when using URLs with "#" in them
-                // see http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-
-                if (typeof scope.disqus_identifier === 'undefined' || typeof scope.disqus_url === 'undefined') {
-                    throw "Please ensure that the `disqus-identifier` and `disqus-url` attributes are both set.";
-                }
+                scope.$watch('config', configChanged, true);
 
-                scope.$watch("readyToBind", function (loadedOn) {
+                function configChanged() {
 
-                    // If the directive has been called without the 'ready-to-bind' attribute, we
-                    // set a default value so that Disqus will be loaded straight away.
-                    if (!angular.isDefined(loadedOn)) {
-                        loadedOn = new Date();
+                    // Ensure that the disqus_identifier and disqus_url are both set, otherwise we will run in to identifier conflicts when using URLs with "#" in them
+                    // see http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-
+                    if (!scope.config.disqus_shortname ||
+                        !scope.config.disqus_identifier ||
+                        !scope.config.disqus_url) {
+                        return;
                     }
-                    var isReady = typeof scope.$eval(loadedOn) !== 'undefined';
-                    if (isReady) {
-                        // put the config variables into separate global vars so that the Disqus script can see them
-                        $window.disqus_shortname = scope.disqus_shortname;
-                        $window.disqus_identifier = scope.disqus_identifier;
-                        $window.disqus_url = scope.disqus_url;
-                        $window.disqus_title = scope.disqus_title;
-                        $window.disqus_category_id = scope.disqus_category_id;
-                        $window.disqus_disable_mobile = scope.disqus_disable_mobile;
-                        $window.disqus_config = function () {
-                            this.language = scope.disqus_config_language;
-                            this.page.remote_auth_s3 = scope.disqus_remote_auth_s3;
-                            this.page.api_key = scope.disqus_api_key;
-                            if (scope.disqus_on_ready) {
-                                this.callbacks.onReady = [function () {
-                                    scope.disqus_on_ready();
-                                }];
-                            }
-                        };
-                        // get the remote Disqus script and insert it into the DOM, but only if it not already loaded (as that will cause warnings)
-                        if (!$window.DISQUS) {
-                            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                            dsq.src = '//' + scope.disqus_shortname + '.disqus.com/embed.js';
-                            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-                        } else {
-                            $window.DISQUS.reset({
-                                reload: true,
-                                config: function () {
-                                    this.page.identifier = scope.disqus_identifier;
-                                    this.page.url = scope.disqus_url;
-                                    this.page.title = scope.disqus_title;
-                                    this.language = scope.disqus_config_language;
-                                    this.page.remote_auth_s3 = scope.disqus_remote_auth_s3;
-                                    this.page.api_key = scope.disqus_api_key;
-                                }
-                            });
+
+                    $window.disqus_shortname = scope.config.disqus_shortname;
+                    $window.disqus_identifier = scope.config.disqus_identifier;
+                    $window.disqus_url = scope.config.disqus_url;
+                    $window.disqus_title = scope.config.disqus_title;
+                    $window.disqus_category_id = scope.config.disqus_category_id;
+                    $window.disqus_disable_mobile = scope.config.disqus_disable_mobile;
+                    $window.disqus_config = function () {
+                        this.language = scope.config.disqus_config_language;
+                        this.page.remote_auth_s3 = scope.config.disqus_remote_auth_s3;
+                        this.page.api_key = scope.config.disqus_api_key;
+                        if (scope.config.disqus_on_ready) {
+                            this.callbacks.onReady = [function () {
+                                scope.config.disqus_on_ready();
+                            }];
                         }
+                    };
+
+                    // Get the remote Disqus script and insert it into the DOM, but only if it not already loaded (as that will cause warnings)
+                    if (!$window.DISQUS) {
+                        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                        dsq.src = '//' + scope.config.disqus_shortname + '.disqus.com/embed.js';
+                        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                    } else {
+                        $window.DISQUS.reset({
+                            reload: true,
+                            config: function () {
+                                this.page.identifier = scope.config.disqus_identifier;
+                                this.page.url = scope.config.disqus_url;
+                                this.page.title = scope.config.disqus_title;
+                                this.language = scope.config.disqus_config_language;
+                                this.page.remote_auth_s3 = scope.config.disqus_remote_auth_s3;
+                                this.page.api_key = scope.config.disqus_api_key;
+                            }
+                        });
                     }
-                });
+                }
             }
         };
     }]);
-
 })();


### PR DESCRIPTION
Michael hi,

After your response I took the liberty to play with the directive from scratch.

Now there is a single 'config' object for the directive, instead of separate properties and watch is on this object. If there is a change in the object, it updates disqus comments. Since 'ready-to-bind' was obsolete, that's gone now.

Directive should be initialized like this;

Html

```
<dir-disqus config="disqusConfig"></dir-disqus>
```

And in controller:

```
$scope.disqusConfig = {
 disqus_shortname: 'Your disqus shortname',
 disqus_identifier: 'Comments identifier',
 disqus_url: 'Comments url'
};
```

Additional notes:
. 'comments powered by disqus' text was removed
. Shortname, id and url are still mandatory, but if they're falsy, it just returns, instead of throwing an exception
. README.md updated accordingly (removed ready-to-bind section & didn't mention breaking changes)
. I'm using jasmine & chutzpah. Tried to update 'tests' file but couldn't make it run in my environment, so didn't touch that one. If you wish I can try to update it blindly?
. Except this 'config' part, didn't change about 'disqus' implementation. So the rest should work, but I only tested basic properties (shortname, identifier, url, onReady callback).
. Updated & uploaded my test page again, so you can quickly check how it works;
Sync: http://dev.forcrowd.org/dirDisqusFix/home?mode=sync
Async: http://dev.forcrowd.org/dirDisqusFix/home?mode=async
Route: http://dev.forcrowd.org/dirDisqusFix/home?mode=route

Hope this is enough for the moment.
Let me know if you notice any issues and of course if one of the changes is not good or not necessary or may cause any other problem.

Regards,
