### PR TITLE
dirDisqus: prevent error when config object is undefined

### DIFF
--- a/src/directives/disqus/dirDisqus.js
+++ b/src/directives/disqus/dirDisqus.js
@@ -37,6 +37,11 @@
                 scope.$watch('config', configChanged, true);
 
                 function configChanged() {
+                    
+                    // Check that the config object isn't undefined before continuing (when data is being passed to it asynchronously, for example)
+                    if (typeof scope.config === 'undefined') {
+                        return;
+                    }
 
                     // Ensure that the disqus_identifier and disqus_url are both set, otherwise we will run in to identifier conflicts when using URLs with "#" in them
                     // see http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-


### PR DESCRIPTION
I ran into this error `TypeError: Cannot read property 'disqus_shortname' of undefined` when using a config object that got their data asynchronously, in my WP REST API + AngularJS front-end blog.

Template:
`<dir-disqus config="disqusConfig"></dir-disqus>`

Controller:


```
afterSomeAjaxStuff(function(){
    $scope.disqusConfig = {
        disqus_shortname: 'beautifulfrontend',
        disqus_identifier: $stateParams.slug,
        disqus_url: $scope.currentURL
    };
});
```

This is just a simple flag to check that the config object actually has some data before continuing to execute the rest of configChanged().

